### PR TITLE
Small fix with HwndObject's operator == and null

### DIFF
--- a/Source/WindowScrape/Types/HwndObject.cs
+++ b/Source/WindowScrape/Types/HwndObject.cs
@@ -118,6 +118,14 @@
 
         public static bool operator ==(HwndObject a, HwndObject b)
         {
+            if (object.ReferenceEquals(a, null))
+            {
+                return object.ReferenceEquals(b, null);
+            }
+            else if (object.ReferenceEquals(b, null))
+            {
+                return object.ReferenceEquals(a, null);
+            }
             return (a.Hwnd == b.Hwnd);
         }
 


### PR DESCRIPTION
Thanks for such a handy library.
I thought HwndObject had better be comparable to null using an operator ==, instead of throwing a NullReferenceException.
per https://msdn.microsoft.com/en-us/library/ms173147(v=vs.90).aspx (seems bit outdated though)


Incidentally, what License is applied on this library? Some says you have simply stated "leaving this open" before, but nothing is mentioned on here Github (sorry if I missed anything).

Regards.